### PR TITLE
WPI: Tag api fix

### DIFF
--- a/cmd/gauge/cli/package.go
+++ b/cmd/gauge/cli/package.go
@@ -28,6 +28,7 @@ func Package() *ffcli.Command {
 		repoURL        = flagset.String("r", "", "repository URL")
 		configfp       = flagset.String("c", "", "configuration file")
 		outputfp       = flagset.String("f", "", "result filepath")
+		deepscan       = flagset.Bool("d", false, "enable deep scan (could be blocked by github API rate-limit)")
 	)
 	return &ffcli.Command{
 		Name:       "package",
@@ -62,6 +63,7 @@ EXAMPLES
 			gopts.PackageOptSelected = true
 			gopts.ControlFilepath = *configfp
 			gopts.ResultFilepath = *outputfp
+			gopts.DeepScanEnabled = *deepscan
 			if gopts.ControlFilepath == "" {
 				pwd, _ := os.Getwd()
 				gopts.ControlFilepath = path.Join(pwd, defaultGaugeConfigFile)

--- a/pkg/core/engine.go
+++ b/pkg/core/engine.go
@@ -295,6 +295,7 @@ func gaugePackageRelease(ctx context.Context, opts common.GaugeOpts, gaugeCtr *g
 	return nil
 }
 
+// never called, logic in pkg/core/reports.go instead
 func printPackageReleaseReport(releaseInsights common.ReleaseInsights, recommendation common.RecommendedVersion) {
 	fmt.Printf(strings.Repeat("*", 80))
 	fmt.Printf("\nGauge Report for package %s:\n", releaseInsights.PackageName)

--- a/pkg/ghapis/release.go
+++ b/pkg/ghapis/release.go
@@ -142,12 +142,17 @@ func (ghcli *GHClient) GetChangeInsights(ctx context.Context, releaseID, baseRel
 	}
 	for _, c := range gc.Commits {
 		prnum, _ := ghcli.getAssociatedPRNumber(ctx, repoOwner, repo, c.GetSHA())
+
 		if prnum != 0 && !contains(prCache, prnum) {
 			pr := ghcli.getPRMeta(ctx, repoOwner, repo, prnum)
+			// missing contributors commitH.Contributors
+			// missing approvers commitH.Approvers
 			pr.Authors = c.GetAuthor().GetLogin()
+
 			commitH.Changes = append(commitH.Changes, pr)
 			prCache[prnum] = struct{}{}
 		} else {
+			// missing contributors commitH.Contributors
 			// zombieChange := common.PullRequest{
 			// 	Commits: 1,
 			// }


### PR DESCRIPTION
Description: 
Fixes for issue #13 

Changes: 
- for ListTag, change the api call to 100 results per page and also loop through all pages
- If the tag doesnt match, strip tag name with "v" to see if it matches better, for juniperOne sbom

WIP because it then gets stuck in a loop, too long to realistically run