### PR TITLE
add deepscan option to package scans

### DIFF
--- a/cmd/gauge/cli/package.go
+++ b/cmd/gauge/cli/package.go
@@ -28,6 +28,7 @@ func Package() *ffcli.Command {
 		repoURL        = flagset.String("r", "", "repository URL")
 		configfp       = flagset.String("c", "", "configuration file")
 		outputfp       = flagset.String("f", "", "result filepath")
+		deepscan       = flagset.Bool("d", false, "enable deep scan (could be blocked by github API rate-limit)")
 	)
 	return &ffcli.Command{
 		Name:       "package",
@@ -62,6 +63,7 @@ EXAMPLES
 			gopts.PackageOptSelected = true
 			gopts.ControlFilepath = *configfp
 			gopts.ResultFilepath = *outputfp
+			gopts.DeepScanEnabled = *deepscan
 			if gopts.ControlFilepath == "" {
 				pwd, _ := os.Getwd()
 				gopts.ControlFilepath = path.Join(pwd, defaultGaugeConfigFile)


### PR DESCRIPTION
PR to resolve #15 

Changes
- Change cmd/gauge/cli/package.go to allow on/off deepscan via flag "-d true" or "-d false"

Note that when deepscan is toggled, it toggles the following fields:
- recommendations:num_uniq_authors
- recommendations:num_uniq_reviewers
- recommendations:zombie_commits
- recommendations:non_peer_reviewed_prs
- recommendations:change_annotations
- insights:commit_history
- insights:annotations